### PR TITLE
Fix runtime errors

### DIFF
--- a/shortcuts.py
+++ b/shortcuts.py
@@ -78,7 +78,8 @@ def findLastEntryNumberAndPosition(pathToShortcutsVDF):
     foundChars = 1
     target = '\x00\x01appname'
     lookingfor = 'target'
-    lastEntryNumber = ''
+    lastEntryNumber = 0
+    lastEntryPosition = 0
 
     f = open(str(pathToShortcutsVDF), 'r')
     fileContents = f.read()


### PR DESCRIPTION
This fixes the `UnboundLocalError: local variable 'lastEntryPosition' referenced before assignment` and `ValueError: invalid literal for int() with base 10: ''` runtime errors, as raised in #1.